### PR TITLE
Lock Index 0 on folders Consul treatment

### DIFF
--- a/ConsulClient/v1/kv/KVResponse.py
+++ b/ConsulClient/v1/kv/KVResponse.py
@@ -13,8 +13,11 @@ class KVResponse(object):
             for kv in body:
                 key = kv["Key"]
                 value = kv["Value"]
-                value_decoded = Utils.decode_base64(value)
-                body_response[key] = value_decoded
+                if value:
+                    value_decoded = Utils.decode_base64(value)
+                    body_response[key] = value_decoded
+                else:
+                    pass
         else:
             body_response = response.text
         return {"successful_response": ok_response, "status_code": status_code, "body": body_response}


### PR DESCRIPTION
### Issue

When there is a folder with no contents, the Lock Index returns `Value: None` under the recursive load. 

```
b'[{"LockIndex":0,"Key":"es-curator/","Flags":0,"Value":null,"CreateIndex":184,"ModifyIndex":184},{"LockIndex":0,"Key":"es-curator/es.curator.config.json","Flags":0,"Value":"eyJlcy...[omitted]...kiO...0=","CreateIndex":187,"ModifyIndex":187},{"LockIndex":0,"Key":"es.curator.config.json","Flags":0,"Value":"eyJ.....[omitted]...0In0=","CreateIndex":181,"ModifyIndex":181},{"LockIndex":0,"Key":"prod/","Flags":0,"Value":null,"CreateIndex":358,"ModifyIndex":358},{"LockIndex":0,"Key":"prod/es-curator/","Flags":0,"Value":null,"CreateIndex":359,"ModifyIndex":359},{"LockIndex":0,"Key":"prod/es-curator/es.curator.config.json","Flags":0,"Value":"eyJlcy...[omitted]...aWx0ZXIiOiI0In0=","CreateIndex":362,"ModifyIndex":364}]'
```

Base64 decoder expects always a value. Breaking on None type. 

```
~/.pyenv/versions/3.7.3/lib/python3.7/base64.py in _bytes_from_decode_data(s)
     44     except TypeError:
     45         raise TypeError("argument should be a bytes-like object or ASCII "
---> 46                         "string, not %r" % s.__class__.__name__) from None
     47
     48
```

This only evaluates payload when there is an actual body. 